### PR TITLE
Update deprecated implicitly nullable types

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -22,10 +22,10 @@ class Database
      * @param bool $webpki Use Webpki (default: false)
      */
     public function __construct(
-        string $path = null,
-        string $url = null,
+        ?string $path = null,
+        ?string $url = null,
         #[\SensitiveParameter]
-        string $authToken = null,
+        ?string $authToken = null,
         #[\SensitiveParameter]
         ?string $encryptionKey = null,
         int $syncInterval = 0,

--- a/src/PDO.php
+++ b/src/PDO.php
@@ -10,7 +10,7 @@ class PDO extends \PDO
     private Database $db;
 
     public function __construct(
-        string $dsn = null,
+        ?string $dsn = null,
         ?string $username = null,
         #[\SensitiveParameter] ?string $password = null,
         #[\SensitiveParameter] ?array $options = [],


### PR DESCRIPTION
These implicit nullable types cause warnings.

See: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

Example:

```
> DB::select('SELECT datetime("now") AS current_time');

   DEPRECATED  Libsql\PDO::__construct(): Implicitly marking parameter $dsn as nullable is deprecated, the explicit nullable type must be used instead in vendor/turso/libsql/src/PDO.php on line 12.
```
